### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ itsdangerous==0.24
 Jinja2==2.9.5
 MarkupSafe==0.23
 packaging==16.8
-pkg-resources==0.0.0
 pyparsing==2.2.0
 six==1.10.0
 Werkzeug==0.11.15


### PR DESCRIPTION
In Ubuntu 16.04 there is error in running-
"Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 8)) (from versions: )
No matching distribution found for pkg-resources==0.0.0 (from -r requirements.txt (line 8))"


When i removed the  pkg-resources==0.0.0 from the requirements.txt its works fine.